### PR TITLE
Make guest page render using one time loaded defaults.

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import path from 'path';
-import handleReactRoutes from './reactRoutes';
+import initReactRoutes from './reactRoutes';
 import dbRoutes from './dbRoutes';
 import auth0Auth from './auth0Auth';
 import restrictRoutes from './restrictRoutes';
@@ -14,7 +14,15 @@ app.use(express.static(path.join(__dirname, '../../dist/public'), { maxage: '315
 auth0Auth(app);
 restrictRoutes(app);
 dbRoutes(app);
-app.use('*', handleReactRoutes);
+app.use('*', (req, res, next) => {
+  initReactRoutes
+    .then((handleReactRoutes) => {
+      handleReactRoutes(req, res, next);
+    })
+    .catch((error) => {
+      throw error;
+    });
+});
 
 app.get('*', (req, res) => {
   res.status(404).end();

--- a/src/server/services/coreCurriculum.js
+++ b/src/server/services/coreCurriculum.js
@@ -157,7 +157,7 @@ const init = (curriculum) => {
 
 /**
  * Build a new curriculum object
- * 
+ *
  * @returns {any} curriculum - Initialized curriculum object
  */
 const getCurriculum = () => {


### PR DESCRIPTION
Since the guest page (= unauthenticated user) is the same for everyone, this PR "caches" default values instead of retrieving the same values over and over again for each request to speed up page delivery and lessen server burden.
The contributor data from the GitHub API is part of those defaults which in turn gets rid of an async API call per page load.